### PR TITLE
Remove unneccessary EVP_get_digestbyname() invocation

### DIFF
--- a/app/backend/nvpairingmanager.cpp
+++ b/app/backend/nvpairingmanager.cpp
@@ -167,11 +167,7 @@ NvPairingManager::signMessage(const QByteArray& message)
     EVP_MD_CTX *ctx = EVP_MD_CTX_create();
     THROW_BAD_ALLOC_IF_NULL(ctx);
 
-    const EVP_MD *md = EVP_get_digestbyname("SHA256");
-    THROW_BAD_ALLOC_IF_NULL(md);
-
-    EVP_DigestInit_ex(ctx, md, NULL);
-    EVP_DigestSignInit(ctx, NULL, md, NULL, m_PrivateKey);
+    EVP_DigestSignInit(ctx, NULL, EVP_sha256(), NULL, m_PrivateKey);
     EVP_DigestSignUpdate(ctx, reinterpret_cast<unsigned char*>(const_cast<char*>(message.data())), message.length());
 
     size_t signatureLength = 0;


### PR DESCRIPTION
This causes problems with pre-OpenSSL 1.1.0 clients that don't call OpenSSL_add_all_algorithms() during initialization. This is known to affect Steam Link on firmware 815.

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [ ] I have read the [Code of Conduct](https://github.com/danopstech/.github/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have updated the documentation accordingly.
- [ ] All commits are GPG signed
